### PR TITLE
Remove unnecessary throws in convert method

### DIFF
--- a/src/main/java/com/github/lalyos/jfiglet/FigletFont.java
+++ b/src/main/java/com/github/lalyos/jfiglet/FigletFont.java
@@ -154,7 +154,7 @@ public class FigletFont {
   }
 
 
-    public String convert(String message) throws IOException {
+    public String convert(String message){
         String result = "";
         for (int l = 0; l < this.height; l++) { // for each line
             for (int c = 0; c < message.length(); c++)

--- a/src/main/java/com/github/lalyos/jfiglet/JFiglet.java
+++ b/src/main/java/com/github/lalyos/jfiglet/JFiglet.java
@@ -2,11 +2,9 @@ package com.github.lalyos.jfiglet;
 
 import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.PrintStream;
 import java.io.PrintWriter;
 import java.io.StringWriter;
-import java.net.URL;
 import java.util.Arrays;
 import java.util.Iterator;
 


### PR DESCRIPTION
The method convert does not have to throws IOException as it may only occur in the FigletFont constructor